### PR TITLE
Fix script paths in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,8 +30,8 @@ Start
 
 To start MobSOS Surveys, use one of the available start scripts:
   
-  * `bin/startNetwork.bat (Win)`
-  * `bin/startNetwork.sh (Unix, Mac)`
+  * `bin/start_network.bat (Win)`
+  * `bin/start_network.sh (Unix, Mac)`
 
 After successful start, MobSOS Surveys is available under
 


### PR DESCRIPTION
The actual file names of the start scripts do not match the script names in the README file.