### PR TITLE
change qkey varchar length

### DIFF
--- a/etc/sql/schema.sql
+++ b/etc/sql/schema.sql
@@ -61,7 +61,7 @@ create table response (
     id bigint not null auto_increment,
     uid varchar(128) not null,
     sid mediumint not null,
-    qkey varchar(32) not null,
+    qkey varchar(36) not null,
     qval varchar(512) not null,
     time datetime not null,
     constraint res_pk primary key (id),


### PR DESCRIPTION
The uuid.v4 which is called when creating a questionnaire, assigns a 36 char string to a question as a question id (qid ~ qkey). This causes a truncation error when sending responses to a questionnaire. 
I also changed this column on the database using `ALTER TABLE response MODIFY qkey VARCHAR(36) NOT NULL;` command