### PR TITLE
add kubernetes configs

### DIFF
--- a/etc/kubernetes/nginx-deployment.yaml
+++ b/etc/kubernetes/nginx-deployment.yaml
@@ -1,0 +1,66 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app: mobsos-surveys-nginx
+  name: mobsos-surveys-nginx
+  namespace: mobsos
+spec:
+  progressDeadlineSeconds: 600
+  replicas: 1
+  revisionHistoryLimit: 10
+  selector:
+    matchLabels:
+      app: mobsos-surveys-nginx
+  strategy:
+    rollingUpdate:
+      maxSurge: 25%
+      maxUnavailable: 25%
+    type: RollingUpdate
+  template:
+    metadata:
+      creationTimestamp: null
+      labels:
+        app: mobsos-surveys-nginx
+    spec:
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+              - matchExpressions:
+                  - key: kubernetes.io/hostname
+                    operator: In
+                    values:
+                      - tech4compslave1
+                      - tech4compslave2
+      containers:
+        - image: registry.tech4comp.dbis.rwth-aachen.de/rwthacis/mobsos-surveys-nginx:develop
+          imagePullPolicy: Always
+          name: mobsos-surveys-nginx
+          ports:
+            - containerPort: 80
+              protocol: TCP
+          resources: {}
+          terminationMessagePath: /dev/termination-log
+          terminationMessagePolicy: File
+          volumeMounts:
+            - mountPath: /src/etc/i5.las2peer.registry.data.RegistryConfiguration.properties
+              name: registry-config-volume
+              subPath: registry-config.properties
+            - mountPath: /src/etc/nodeInfo.xml
+              name: node-info-volume
+              subPath: nodeInfo.xml
+      dnsPolicy: ClusterFirst
+      restartPolicy: Always
+      schedulerName: default-scheduler
+      securityContext: {}
+      terminationGracePeriodSeconds: 30
+      volumes:
+        - configMap:
+            defaultMode: 420
+            name: registry-config
+          name: registry-config-volume
+        - configMap:
+            defaultMode: 420
+            name: node-info
+          name: node-info-volume

--- a/etc/kubernetes/nginx-ingress.yaml
+++ b/etc/kubernetes/nginx-ingress.yaml
@@ -1,0 +1,22 @@
+apiVersion: extensions/v1beta1
+kind: Ingress
+metadata:
+  annotations:
+    kubernoetes.io/ingress.class: nginx
+    nginx.ingress.kubernetes.io/rewrite-target: /$1
+  name: mobsos-surveys-2
+  namespace: mobsos
+spec:
+  rules:
+    - host: surveys.tech4comp.dbis.rwth-aachen.de
+      http:
+        paths:
+          - backend:
+              serviceName: mobsos-surveys-nginx
+              servicePort: 8080
+            path: /static/(.*)
+            pathType: ImplementationSpecific
+  tls:
+    - hosts:
+        - surveys.tech4comp.dbis.rwth-aachen.de
+      secretName: nginx-tls

--- a/etc/kubernetes/nginx-service.yaml
+++ b/etc/kubernetes/nginx-service.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: mobsos-surveys-nginx
+  namespace: mobsos
+spec:
+  ports:
+    - name: surveys-nginx
+      port: 8080
+      protocol: TCP
+      targetPort: 80
+  selector:
+    app: mobsos-surveys-nginx
+  type: ClusterIP

--- a/etc/kubernetes/surveys-deployment.yaml
+++ b/etc/kubernetes/surveys-deployment.yaml
@@ -1,0 +1,92 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app: mobsos-surveys
+  name: mobsos-surveys
+  namespace: mobsos
+spec:
+  progressDeadlineSeconds: 600
+  replicas: 1
+  revisionHistoryLimit: 10
+  selector:
+    matchLabels:
+      app: mobsos-surveys
+  strategy:
+    rollingUpdate:
+      maxSurge: 25%
+      maxUnavailable: 25%
+    type: RollingUpdate
+  template:
+    metadata:
+      creationTimestamp: null
+      labels:
+        app: mobsos-surveys
+    spec:
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+              - matchExpressions:
+                  - key: kubernetes.io/hostname
+                    operator: In
+                    values:
+                      - tech4compslave1
+                      - tech4compslave2
+      containers:
+        - env:
+            - name: BOOTSTRAP
+              value: tech4comp.dbis.rwth-aachen.de:31012
+            - name: LAS2PEER_ETH_HOST
+              value: las2peer-ethnet:8545
+            - name: LAS2PEER_PORT
+              value: "31026"
+            - name: MYSQL_PASSWORD
+              value: password
+            - name: MYSQL_USER
+              value: root
+            - name: MYSQL_HOST
+              value: mobsos-mysql
+            - name: OIDC_CLIENT_ID
+              value: f8622260-875b-499a-82db-db55f89f9deb
+            - name: NODE_ID_SEED
+              value: "5"
+            - name: EP_URL
+              value: https://surveys.tech4comp.dbis.rwth-aachen.de
+            - name: STATIC_CONTENT_URL
+              value: https://surveys.tech4comp.dbis.rwth-aachen.de/static
+            - name: LAS2PEER_URL
+              value: https://las2peer.tech4comp.dbis.rwth-aachen.de/
+            - name: OIDC_PROVIDER_URL
+              value: https://api.learning-layers.eu/auth/realms/main
+            - name: OIDC_PROVIDER_LOGO
+              value: http://results.learning-layers.eu/images/learning-layers.svg
+            - name: WALLET
+              value: "1"
+          image: rwthacis/mobsos-surveys:develop
+          imagePullPolicy: Always
+          name: mobsos-surveys
+          resources: {}
+          terminationMessagePath: /dev/termination-log
+          terminationMessagePolicy: File
+          volumeMounts:
+            - mountPath: /src/etc/i5.las2peer.registry.data.RegistryConfiguration.properties
+              name: registry-config-volume
+              subPath: registry-config.properties
+            - mountPath: /src/etc/nodeInfo.xml
+              name: node-info-volume
+              subPath: nodeInfo.xml
+      dnsPolicy: ClusterFirst
+      restartPolicy: Always
+      schedulerName: default-scheduler
+      securityContext: {}
+      terminationGracePeriodSeconds: 30
+      volumes:
+        - configMap:
+            defaultMode: 420
+            name: registry-config
+          name: registry-config-volume
+        - configMap:
+            defaultMode: 420
+            name: node-info
+          name: node-info-volume

--- a/etc/kubernetes/surveys-ingress.yaml
+++ b/etc/kubernetes/surveys-ingress.yaml
@@ -1,0 +1,22 @@
+apiVersion: extensions/v1beta1
+kind: Ingress
+metadata:
+  annotations:
+    kubernetes.io/ingress.class: nginx
+    nginx.ingress.kubernetes.io/rewrite-target: /mobsos-surveys/$1
+  name: mobsos-surveys
+  namespace: mobsos
+spec:
+  rules:
+    - host: surveys.tech4comp.dbis.rwth-aachen.de
+      http:
+        paths:
+          - backend:
+              serviceName: mobsos-surveys-webconnector
+              servicePort: 8080
+            path: /(.*)
+            pathType: ImplementationSpecific
+  tls:
+    - hosts:
+        - surveys.tech4comp.dbis.rwth-aachen.de
+      secretName: nginx-tls

--- a/etc/kubernetes/surveys-service.yaml
+++ b/etc/kubernetes/surveys-service.yaml
@@ -1,0 +1,20 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: mobsos-surveys
+  namespace: mobsos
+spec:
+  ports:
+    - name: surveys
+      nodePort: 31026
+      port: 31026
+      protocol: TCP
+      targetPort: 31026
+    - name: surveys-pastry
+      nodePort: 31026
+      port: 31026
+      protocol: UDP
+      targetPort: 31026
+  selector:
+    app: mobsos-surveys
+  type: NodePort


### PR DESCRIPTION
The nginx issue is finally solved and now the service is working fine and pretty fast. It reduced the page loading time from 9 seconds to 1 second.

The files related to nginx are new and is added in the current task so it is good if you have a look at them. I also exported the kubernetes configs for the service itself here so that it becomes version controlled. 

There was also an error in the surveys ingress which would cause only the main page of the service be served and block all other urls. This one got fixed by the following changes:

- path: /$(.\*) --> /(.\*)
- rewrite-target: /mobsos-surveys/$2 --> /mobsos-surveys/$1